### PR TITLE
Support generic OpenAI models

### DIFF
--- a/src/vss_ctx_rag/context_manager/context_manager_handler.py
+++ b/src/vss_ctx_rag/context_manager/context_manager_handler.py
@@ -54,7 +54,7 @@ from vss_ctx_rag.functions.rag.graph_rag.graph_retrieval_func import GraphRetrie
 from vss_ctx_rag.functions.rag.vector_rag.vector_retrieval_func import (
     VectorRetrievalFunc,
 )
-from vss_ctx_rag.utils.utils import RequestInfo
+from vss_ctx_rag.utils.utils import RequestInfo, is_openai_model
 
 
 class ContextManagerHandler:
@@ -165,7 +165,7 @@ class ContextManagerHandler:
         notification_config = config.get("notification")
         if notification_config and notification_config.get("enable"):
             notification_llm_params = notification_config.get("llm")
-            if notification_llm_params["model"] == "gpt-4o":
+            if is_openai_model(notification_llm_params["model"]):
                 api_key = os.environ["OPENAI_API_KEY"]
             else:
                 api_key = config["api_key"]
@@ -194,7 +194,7 @@ class ContextManagerHandler:
             if chat_config
             else DEFAULT_LLM_PARAMS
         )
-        if chat_llm_params["model"] == "gpt-4o":
+        if is_openai_model(chat_llm_params["model"]):
             api_key = os.environ["OPENAI_API_KEY"]
         else:
             api_key = config["api_key"]
@@ -203,7 +203,7 @@ class ContextManagerHandler:
         # Init time Summarization config
         summ_config = copy.deepcopy(config.get("summarization"))
         llm_params = summ_config.get(LLM_TOOL_NAME, DEFAULT_LLM_PARAMS)
-        if llm_params["model"] == "gpt-4o":
+        if is_openai_model(llm_params["model"]):
             api_key = os.environ["OPENAI_API_KEY"]
         else:
             api_key = config["api_key"]

--- a/src/vss_ctx_rag/tools/llm/llm_handler.py
+++ b/src/vss_ctx_rag/tools/llm/llm_handler.py
@@ -21,6 +21,7 @@ from langchain_core.runnables.utils import ConfigurableField
 from vss_ctx_rag.base import Tool
 from vss_ctx_rag.utils.ctx_rag_logger import logger
 from vss_ctx_rag.utils.globals import DEFAULT_LLM_BASE_URL
+from vss_ctx_rag.utils.utils import is_openai_model
 from langchain_core.runnables.base import Runnable
 from langchain_nvidia_ai_endpoints import register_model, Model, ChatNVIDIA
 
@@ -68,7 +69,7 @@ class ChatOpenAITool(LLMTool):
     def __init__(
         self, model=None, api_key=None, base_url=DEFAULT_LLM_BASE_URL, **llm_params
     ) -> None:
-        if model and model == "gpt-4o":
+        if model and is_openai_model(model):
             base_url = ""
             super().__init__(
                 llm=ChatOpenAI(

--- a/src/vss_ctx_rag/utils/utils.py
+++ b/src/vss_ctx_rag/utils/utils.py
@@ -83,6 +83,37 @@ def remove_lucene_chars(text: str) -> str:
     return text.strip()
 
 
+def is_openai_model(model_name: str) -> bool:
+    """Return True if the model name refers to an OpenAI model."""
+
+    model = model_name.lower()
+
+    openai_prefixes = (
+        "gpt-",
+        "gpt_image-",
+        "text-",
+        "dall-e",
+        "davinci",
+        "babbage",
+        "codex",
+        "chatgpt",
+        "tts-",
+        "whisper-",
+        "computer-",
+        "text-embedding",
+        "omni",
+    )
+
+    if any(model.startswith(prefix) for prefix in openai_prefixes):
+        return True
+
+    # Matches o models like "o1", "o1-preview", "o3-mini", "01" etc.
+    if re.match(r"^[o0]\d", model):
+        return True
+
+    return False
+
+
 class RequestInfo:
     def __init__(
         self,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,47 @@
+import os
+import ast
+import re
+
+import pytest
+
+# Extract the is_openai_model function source from utils.py without importing the module
+utils_path = os.path.join(os.path.dirname(__file__), "..", "src", "vss_ctx_rag", "utils", "utils.py")
+with open(utils_path) as f:
+    source = f.read()
+
+module = ast.parse(source)
+func_source = None
+for node in module.body:
+    if isinstance(node, ast.FunctionDef) and node.name == "is_openai_model":
+        func_source = ast.get_source_segment(source, node)
+        break
+
+namespace = {"re": re}
+exec(func_source, namespace)
+
+is_openai_model = namespace["is_openai_model"]
+
+@pytest.mark.parametrize("model", [
+    "gpt-4o",
+    "gpt-4.5-preview",
+    "gpt-image-1",
+    "dall-e-3",
+    "davinci-002",
+    "babbage-002",
+    "codex-mini-latest",
+    "chatgpt-4o-latest",
+    "tts-1",
+    "whisper-1",
+    "computer-use-preview",
+    "text-embedding-3-small",
+    "omni-moderation-latest",
+    "o1-preview",
+    "o1-mini",
+    "o3-mini",
+    "o1-pro",
+    "o4-mini",
+    "01-mini",  # zero prefix variant
+])
+def test_is_openai_model(model):
+    assert is_openai_model(model)
+


### PR DESCRIPTION
## Summary
- allow detecting a broader set of OpenAI model prefixes
- test that the helper recognizes many official model names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845adc4b26483279aa8e898e87a2a7e