### PR TITLE
Add endless_ai_enabled option

### DIFF
--- a/docs/source/intro/setup.md
+++ b/docs/source/intro/setup.md
@@ -182,6 +182,7 @@ with open("config/config.yaml", mode="r", encoding="utf8") as c:
             self.notification_temperature = None
             self.notification_max_tokens = None
             self.rag_type = config["chat"]["rag"]
+            self.endless_ai_enabled = False
 
     req_info = RequestInfo()
 

--- a/service/models.py
+++ b/service/models.py
@@ -73,6 +73,7 @@ class RequestInfo(BaseModel):
     notification_temperature: Optional[float] = None
     notification_max_tokens: Optional[int] = None
     rag_type: str = "vector-rag"
+    endless_ai_enabled: bool = False
 
 
 class CallRequest(BaseModel):

--- a/src/vss_ctx_rag/aiq/utils.py
+++ b/src/vss_ctx_rag/aiq/utils.py
@@ -47,6 +47,7 @@ class RequestInfo:
         self.notification_temperature = None
         self.notification_max_tokens = None
         self.rag_type = "vector-rag"
+        self.endless_ai_enabled = False
 
 
 def aiq_to_vss_config(
@@ -143,6 +144,7 @@ def create_vss_ctx_rag_config(name: str):
         enable_chat: Optional[bool] = True
         is_live: Optional[bool] = False
         uuid: Optional[str] = "1"
+        endless_ai_enabled: Optional[bool] = False
 
     return VssCtxRagToolConfig
 
@@ -158,3 +160,6 @@ def update_request_info(config, req_info):
     for field in vars(req_info).keys():
         if hasattr(config, field):
             setattr(req_info, field, getattr(config, field))
+
+    if hasattr(config, "endless_ai_enabled"):
+        req_info.endless_ai_enabled = getattr(config, "endless_ai_enabled")

--- a/src/vss_ctx_rag/context_manager/context_manager.py
+++ b/src/vss_ctx_rag/context_manager/context_manager.py
@@ -330,6 +330,7 @@ class ContextManager:
                     "chunk_size": req_info.chunk_size,
                     "summary_duration": req_info.summary_duration,
                     "rag_type": req_info.rag_type,
+                    "endless_ai_enabled": req_info.endless_ai_enabled,
                 }
             )
         self.process.configure_update(config=config, req_info=req_info_obj)

--- a/src/vss_ctx_rag/utils/utils.py
+++ b/src/vss_ctx_rag/utils/utils.py
@@ -98,13 +98,16 @@ def is_openai_model(model_name: str) -> bool:
         "chatgpt",
         "tts-",
         "whisper-",
+        "computer-use",
+        "text-embedding",
+        "omni-moderation",
     )
 
     if any(model.startswith(prefix) for prefix in openai_prefixes):
         return True
 
     # Matches o models like "o1", "o1-preview", "o3-mini", "o4-mini" etc.
-    if re.match(r"^[o]\d", model):
+    if re.match(r"^[o0]\d", model):
         return True
 
     return False
@@ -131,6 +134,7 @@ class RequestInfo:
         notification_temperature: Optional[float] = None,
         notification_max_tokens: Optional[int] = None,
         rag_type: Optional[str] = None,
+        endless_ai_enabled: bool = False,
     ):
         self.summarize = summarize
         self.enable_chat = enable_chat
@@ -150,6 +154,7 @@ class RequestInfo:
         self.notification_temperature = notification_temperature
         self.notification_max_tokens = notification_max_tokens
         self.rag_type = rag_type
+        self.endless_ai_enabled = endless_ai_enabled
 
 
 def validate_config(config: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- allow enabling Endless AI via config fields and RequestInfo
- expose the new option through the AIQ config utilities
- forward endless_ai_enabled through ContextManager.configure_update
- document endless_ai_enabled usage in setup docs
- extend OpenAI model check utility to cover more model names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68501f6e1a30832daafca5d837caa86a