### PR TITLE
Handle multimodal messages based on model

### DIFF
--- a/src/vss_ctx_rag/utils/utils.py
+++ b/src/vss_ctx_rag/utils/utils.py
@@ -101,13 +101,17 @@ def is_openai_model(model_name: str) -> bool:
         "chatgpt",
         "tts-",
         "whisper-",
+        "computer-use-",
+        "text-embedding-",
+        "omni-",
     )
 
     if any(model.startswith(prefix) for prefix in openai_prefixes):
         return True
 
     # Matches o models like "o1", "o1-preview", "o3-mini", "o4-mini" etc.
-    if re.match(r"^[o]\d", model):
+    # Also handle zero prefix variants like "01-mini"
+    if re.match(r"^[o0]\d", model):
         return True
 
     return False
@@ -127,6 +131,24 @@ def is_claude_model(model_name: str) -> bool:
     )
 
     return any(model.startswith(prefix) for prefix in claude_prefixes)
+
+
+def model_supports_multimodal_messages(model_name: str) -> bool:
+    """Return True if the model supports multimodal (text + image) messages."""
+
+    model = model_name.lower()
+
+    multimodal_substrings = [
+        "gpt-4o",
+        "gpt-4-vision",
+        "gpt-4v",
+        "gpt-4-turbo",
+        "gpt-4-1106",
+        "gpt-4-turbo-preview",
+        "claude-3",
+    ]
+
+    return any(sub in model for sub in multimodal_substrings)
 
 
 class RequestInfo:

--- a/tests/test_prepare_messages.py
+++ b/tests/test_prepare_messages.py
@@ -1,0 +1,139 @@
+import ast
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+utils_path = os.path.join(os.path.dirname(__file__), "..", "src", "vss_ctx_rag", "utils", "utils.py")
+with open(utils_path) as f:
+    utils_src = f.read()
+
+utils_mod = ast.parse(utils_src)
+helper_src = None
+for node in utils_mod.body:
+    if isinstance(node, ast.FunctionDef) and node.name == "model_supports_multimodal_messages":
+        helper_src = ast.get_source_segment(utils_src, node)
+        break
+
+helper_ns = {}
+exec(helper_src, helper_ns)
+model_supports_multimodal_messages = helper_ns["model_supports_multimodal_messages"]
+
+LLM_TOOL_NAME = "llm"
+
+class DummyMessage:
+    def __init__(self, content):
+        self.content = content
+
+SystemMessage = DummyMessage
+HumanMessage = DummyMessage
+
+
+def _extract_function(path, class_name, method_name, inner_name):
+    with open(path) as f:
+        src = f.read()
+    mod = ast.parse(src)
+    for node in mod.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for cls_node in node.body:
+                if isinstance(cls_node, ast.FunctionDef) and cls_node.name == method_name:
+                    for inner in cls_node.body:
+                        if isinstance(inner, ast.FunctionDef) and inner.name == inner_name:
+                            return ast.get_source_segment(src, inner)
+    raise ValueError("function not found")
+
+BATCH_PATH = os.path.join(os.path.dirname(__file__), "..", "src", "vss_ctx_rag", "functions", "summarization", "batch.py")
+GRAPH_PATH = os.path.join(os.path.dirname(__file__), "..", "src", "vss_ctx_rag", "functions", "rag", "graph_rag", "graph_retrieval.py")
+
+
+class DummyLLM:
+    def __init__(self, model):
+        self.model = model
+        self.model_id = model
+
+class DummyTool:
+    def __init__(self, model):
+        self.llm = DummyLLM(model)
+
+class DummyBatchSelf:
+    def __init__(self, model):
+        self.tool = DummyTool(model)
+    def get_tool(self, name):
+        return self.tool
+    def get_param(self, *keys):
+        return {
+            "prompts": {"caption_summarization": "cap"}
+        }[keys[0]][keys[1]]
+
+class DummyGraphSelf:
+    def __init__(self, model, endless=True):
+        self.chat_llm = DummyLLM(model)
+        self.endless_ai_enabled = endless
+    def get_tool(self, name):
+        return None
+
+CHAT_SYSTEM_TEMPLATE = "chat"
+CHAT_SYSTEM_GRID_TEMPLATE = "grid"
+
+batch_src = _extract_function(BATCH_PATH, "BatchSummarization", "setup", "prepare_messages")
+graph_src = _extract_function(GRAPH_PATH, "GraphRetrieval", "__init__", "prepare_messages")
+
+
+def test_batch_prepare_messages_multimodal():
+    ns = {
+        "SystemMessage": SystemMessage,
+        "HumanMessage": HumanMessage,
+        "LLM_TOOL_NAME": LLM_TOOL_NAME,
+        "model_supports_multimodal_messages": model_supports_multimodal_messages,
+    }
+    self_obj = DummyBatchSelf("gpt-4o")
+    ns["self"] = self_obj
+    exec(batch_src, ns)
+    res = ns["prepare_messages"]({"input": "hello", "images": ["img"]})
+    assert isinstance(res[1].content, list)
+    assert any(b.get("type") == "image_url" for b in res[1].content[1:])
+
+
+def test_batch_prepare_messages_text_only():
+    ns = {
+        "SystemMessage": SystemMessage,
+        "HumanMessage": HumanMessage,
+        "LLM_TOOL_NAME": LLM_TOOL_NAME,
+        "model_supports_multimodal_messages": model_supports_multimodal_messages,
+    }
+    self_obj = DummyBatchSelf("gpt-3.5-turbo")
+    ns["self"] = self_obj
+    exec(batch_src, ns)
+    res = ns["prepare_messages"]({"input": "hello", "images": ["img"]})
+    assert res[1].content == "hello"
+
+
+def test_graph_prepare_messages_multimodal():
+    ns = {
+        "SystemMessage": SystemMessage,
+        "HumanMessage": HumanMessage,
+        "model_supports_multimodal_messages": model_supports_multimodal_messages,
+        "CHAT_SYSTEM_TEMPLATE": CHAT_SYSTEM_TEMPLATE,
+        "CHAT_SYSTEM_GRID_TEMPLATE": CHAT_SYSTEM_GRID_TEMPLATE,
+    }
+    self_obj = DummyGraphSelf("claude-3-opus", endless=True)
+    ns["self"] = self_obj
+    exec(graph_src, ns)
+    res = ns["prepare_messages"]({"input": "hi", "images": ["img"], "messages": []})
+    assert isinstance(res[-1].content, list)
+    assert any(b.get("type") == "image_url" for b in res[-1].content[1:])
+
+
+def test_graph_prepare_messages_text_only():
+    ns = {
+        "SystemMessage": SystemMessage,
+        "HumanMessage": HumanMessage,
+        "model_supports_multimodal_messages": model_supports_multimodal_messages,
+        "CHAT_SYSTEM_TEMPLATE": CHAT_SYSTEM_TEMPLATE,
+        "CHAT_SYSTEM_GRID_TEMPLATE": CHAT_SYSTEM_GRID_TEMPLATE,
+    }
+    self_obj = DummyGraphSelf("gpt-3.5-turbo", endless=True)
+    ns["self"] = self_obj
+    exec(graph_src, ns)
+    res = ns["prepare_messages"]({"input": "hi", "images": ["img"], "messages": []})
+    assert res[-1].content == "User question: hi"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,9 @@
 import os
+import sys
 import ast
 import re
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 import pytest
 
@@ -10,17 +13,20 @@ with open(utils_path) as f:
     source = f.read()
 
 module = ast.parse(source)
-func_source = None
+openai_src = None
+claude_src = None
 for node in module.body:
     if isinstance(node, ast.FunctionDef) and node.name == "is_openai_model":
-        func_source = ast.get_source_segment(source, node)
-        break
+        openai_src = ast.get_source_segment(source, node)
+    if isinstance(node, ast.FunctionDef) and node.name == "is_claude_model":
+        claude_src = ast.get_source_segment(source, node)
 
 namespace = {"re": re}
-exec(func_source, namespace)
+exec(openai_src, namespace)
+exec(claude_src, namespace)
 
 is_openai_model = namespace["is_openai_model"]
-from vss_ctx_rag.utils.utils import is_claude_model
+is_claude_model = namespace["is_claude_model"]
 
 @pytest.mark.parametrize("model", [
     "gpt-4o",


### PR DESCRIPTION
## Summary
- add `model_supports_multimodal_messages` helper
- update summarization and graph retrieval to only include images when supported
- extend OpenAI model detection
- add tests for message preparation with multimodal and text-only models
- update utils tests to avoid importing heavy deps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e340d57bc832780dd5462bc5eec5b