### PR TITLE
NVID-47 - move user question before grid images

### DIFF
--- a/src/vss_ctx_rag/functions/rag/graph_rag/graph_retrieval.py
+++ b/src/vss_ctx_rag/functions/rag/graph_rag/graph_retrieval.py
@@ -94,15 +94,13 @@ class GraphRetrieval:
             for msg in inputs["messages"]:
                 messages.append(msg)
 
-            content_blocks = []
+            # Add the user question before the images (if any)
+            content_blocks = [{"type": "text", "text": f"User question: {inputs['input']}"}]
             if self.endless_ai_enabled:
                 # Add image blocks if any are present
                 images = inputs.get("images", [])
                 # logger.info(f"Length of {len(images)} images={sum(len(img) for img in images)}")
                 content_blocks.extend({"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{img}"}} for img in images)
-
-            # Add the user question after the images (if any)
-            content_blocks.append({"type": "text", "text": f"User question: {inputs['input']}"})
 
             messages.append(HumanMessage(content=content_blocks))
 


### PR DESCRIPTION
move the user question before the images, since we saw that it provides a much smarter response when grids are supplied.